### PR TITLE
fix: sequelize-cli moved to production depedencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "jsonwebtoken": "^8.5.1",
     "mysql2": "^2.2.5",
     "sequelize": "^6.3.5",
+    "sequelize-cli": "^6.2.0",
     "typescript": "^4.0.5"
   },
   "devDependencies": {
@@ -43,7 +44,6 @@
     "factory-girl": "^5.0.4",
     "faker": "^5.1.0",
     "jest": "^26.6.3",
-    "sequelize-cli": "^6.2.0",
     "sqlite3": "^5.0.0",
     "supertest": "^6.0.1",
     "ts-jest": "^26.4.4",


### PR DESCRIPTION
## Description

Sequelize-cli moved to production depedencies

## Checklist

- [x] sequelize-cli dependencie moved to production depedencies